### PR TITLE
Fix cwrsync package.

### DIFF
--- a/cwrsync/cwrsync.nuspec
+++ b/cwrsync/cwrsync.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>cwrsync</id>
-    <version>5.2.2</version>
+    <version>5.2.2.1</version>
     <title>cwRsync Free edition</title>
     <authors>ITeFix</authors>
     <owners>Patrick Wyatt</owners>

--- a/cwrsync/tools/chocolateyInstall.ps1
+++ b/cwrsync/tools/chocolateyInstall.ps1
@@ -1,9 +1,19 @@
 $packageName = 'cwrsync'
+$version = '3.1.0'
 $url = 'https://www.itefix.no/i2/sites/all/modules/pubdlcnt/pubdlcnt.php?file=https://www.itefix.no/download/cwRsync_5.2.2_Free.zip'
 
 try {
   $installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+  # Unzip cwrsync zip, but ignore all executables
   Install-ChocolateyZipPackage "$packageName" "$url" "$installDir"
+  Set-Content -Path ("$installDir\$version\ssh.exe.ignore") -Value $null
+  Set-Content -Path ("$installDir\$version\ssh-keygen.exe.ignore") -Value $null
+  Set-Content -Path ("$installDir\$version\rsync.exe.ignore") -Value $null
+
+  # Install a script that add path to rsync executables before launching it
+  Install-ChocolateyPowershellCommand "$packageName" "$installDir\rsync.ps1"
+
   Write-ChocolateySuccess "$packageName"
 }
 catch {

--- a/cwrsync/tools/rsync.ps1
+++ b/cwrsync/tools/rsync.ps1
@@ -1,0 +1,3 @@
+$currentDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+$env:Path =  "$currentDir\\3.1.0;" + $env:Path
+& "$currentDir\3.1.0\rsync.exe" $args


### PR DESCRIPTION
rsync needs to have ssh.exe in the Path.
To avoid adding chocolatey internal path, create a script that set the
path and call rsync."
